### PR TITLE
chore: update Docusaurus to 3.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.7.0",
-    "@docusaurus/plugin-google-gtag": "^3.7.0",
-    "@docusaurus/preset-classic": "^3.7.0",
+    "@docusaurus/core": "^3.10.2",
+    "@docusaurus/plugin-google-gtag": "^3.10.2",
+    "@docusaurus/preset-classic": "^3.10.2",
     "@mdx-js/react": "^3.0.0",
     "@svgr/webpack": "^8.1.0",
     "clsx": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@11ty/gray-matter@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@11ty/gray-matter/-/gray-matter-1.0.0.tgz#35ee04d76b870893c053f64f659c923a7a9db2d7"
+  integrity sha512-7mJJl+wf1AByoT0PknQiQfOPnVNT4fevGrUBVWO4HXsnYn1aQPyRyrELYrNUFleUBM++KzMKN6QaxHPk0t/6/g==
+  dependencies:
+    js-yaml "^4.1.0"
+    kind-of "^6.0.3"
+    section-matter "^1.0.0"
+    strip-bom-string "^1.0.0"
+
 "@algolia/abtesting@1.18.1":
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/@algolia/abtesting/-/abtesting-1.18.1.tgz#f6f6c221ec463eb3237756d41606c9fb364843dd"
@@ -1499,10 +1509,10 @@
     "@docsearch/core" "4.6.3"
     "@docsearch/css" "4.6.3"
 
-"@docusaurus/babel@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/babel/-/babel-3.10.1.tgz#2f714f682117658ba43d308e9b35b6a73a105227"
-  integrity sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==
+"@docusaurus/babel@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/babel/-/babel-3.10.2.tgz#4d5f8ac4d16bfe26c06f256687831787edb46e8a"
+  integrity sha512-aJ1hpGyvfkte3dDAfNbWM4biW4yWZBVz7TIGLZP+v+tWOBgxX3e0N5ZIXHIvmfNNXTI77pcHUx3KmtOk05Ze3Q==
   dependencies:
     "@babel/core" "^7.25.9"
     "@babel/generator" "^7.25.9"
@@ -1513,23 +1523,23 @@
     "@babel/preset-typescript" "^7.25.9"
     "@babel/runtime" "^7.25.9"
     "@babel/traverse" "^7.25.9"
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
     babel-plugin-dynamic-import-node "^2.3.3"
     fs-extra "^11.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/bundler@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/bundler/-/bundler-3.10.1.tgz#82fa5079f3787a67502e25f82d37d05ec5de0cc3"
-  integrity sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==
+"@docusaurus/bundler@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/bundler/-/bundler-3.10.2.tgz#323492eb0550b6a7f6e5fa6b9877cdb2c53b1be3"
+  integrity sha512-i0ZNcy0f0WhaOlYVgzLsWhIoEXO9kS3HRoKPtgE6vQtZUq7arKZaYdNBudr3mqCmd+TyOkwtwfHgs1ENj07r5g==
   dependencies:
     "@babel/core" "^7.25.9"
-    "@docusaurus/babel" "3.10.1"
-    "@docusaurus/cssnano-preset" "3.10.1"
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
+    "@docusaurus/babel" "3.10.2"
+    "@docusaurus/cssnano-preset" "3.10.2"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
     babel-loader "^9.2.1"
     clean-css "^5.3.3"
     copy-webpack-plugin "^11.0.0"
@@ -1549,18 +1559,18 @@
     webpack "^5.95.0"
     webpackbar "^7.0.0"
 
-"@docusaurus/core@3.10.1", "@docusaurus/core@^3.7.0":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.10.1.tgz#3f8bdb97451b4df14f2a3b39ab0186366fbf8fbe"
-  integrity sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==
+"@docusaurus/core@3.10.2", "@docusaurus/core@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.10.2.tgz#349cae728fc3769b3f8aef4cf538ccb79aace8d0"
+  integrity sha512-EYByj6nk+aD9KeVxV6Hmo2/nAAT79P21Y82ycTBOBtrmqilloIbIEhgL2/8Xpt2Jz/pgNqHAwyusOGwmbKeJmA==
   dependencies:
-    "@docusaurus/babel" "3.10.1"
-    "@docusaurus/bundler" "3.10.1"
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/mdx-loader" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-common" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/babel" "3.10.2"
+    "@docusaurus/bundler" "3.10.2"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/mdx-loader" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-common" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     boxen "^6.2.1"
     chalk "^4.1.2"
     chokidar "^3.5.3"
@@ -1568,7 +1578,7 @@
     combine-promises "^1.1.0"
     commander "^5.1.0"
     core-js "^3.31.1"
-    detect-port "^1.5.1"
+    detect-port "^2.1.0"
     escape-html "^1.0.3"
     eta "^2.2.0"
     eval "^0.1.8"
@@ -1597,32 +1607,32 @@
     webpack-dev-server "^5.2.2"
     webpack-merge "^6.0.1"
 
-"@docusaurus/cssnano-preset@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz#4b6bafeca8bb9423364d2fd6683c28e2f85a4665"
-  integrity sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==
+"@docusaurus/cssnano-preset@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.2.tgz#e3ac7e85585f77e8fdef95176ab7c211d1296630"
+  integrity sha512-4gCnHRbJLTloiwfvFAa92tgb2gI4KYhvjfQVYnEaiMO/EgvWfCo1LwytHXen+1oZAN0VAlS0JAPxp3MsvKDa3A==
   dependencies:
     cssnano-preset-advanced "^6.1.2"
     postcss "^8.5.4"
     postcss-sort-media-queries "^5.2.0"
     tslib "^2.6.0"
 
-"@docusaurus/logger@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-3.10.1.tgz#34c964e32e18f120e30f80171a38cfefe72cfb4b"
-  integrity sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==
+"@docusaurus/logger@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-3.10.2.tgz#280bed53d0eb9cdc56e896a155036207910e89c9"
+  integrity sha512-gSEwqtPfCAnC3ZSJY6xL7tcIfgg0vFD39jbv93eakuweyvO2864xR0K+kmKwBhkTCtWRNjuGGnb5rdmkD/ndqw==
   dependencies:
     chalk "^4.1.2"
     tslib "^2.6.0"
 
-"@docusaurus/mdx-loader@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz#050ae9bc614158a4ec07a628aa75fa9ae90d7e82"
-  integrity sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==
+"@docusaurus/mdx-loader@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-3.10.2.tgz#3b4e7ffacff4ed856db2ec4e94c13b0a652d62eb"
+  integrity sha512-9Fd4V/SFjfrVQ0JH5EN0+iPWyFunvTeQE3gfyFeetqPaXMP0OylIjOw16dCuXG4NZJrYdBqwzjh18/h3gRi47w==
   dependencies:
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     "@mdx-js/mdx" "^3.0.0"
     "@slorber/remark-comment" "^1.0.0"
     escape-html "^1.0.3"
@@ -1645,12 +1655,12 @@
     vfile "^6.0.1"
     webpack "^5.88.1"
 
-"@docusaurus/module-type-aliases@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz#22d39177c296786eb6e0d940699cd590cc93ca77"
-  integrity sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==
+"@docusaurus/module-type-aliases@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz#7c3b940c77d72e71d33a1e76f0e003b418e6163a"
+  integrity sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==
   dependencies:
-    "@docusaurus/types" "3.10.1"
+    "@docusaurus/types" "3.10.2"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1658,19 +1668,19 @@
     react-helmet-async "npm:@slorber/react-helmet-async@1.3.0"
     react-loadable "npm:@docusaurus/react-loadable@6.0.0"
 
-"@docusaurus/plugin-content-blog@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz#0bd8de700ccbd8e95d920df2613304ef59abe72b"
-  integrity sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==
+"@docusaurus/plugin-content-blog@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.2.tgz#2374886ec3d76e8f014e85db8c3c010de6c419be"
+  integrity sha512-0cbEnNKf0InmLkhj/+nVRmqEnWEoOE8Mh+2x1qOXI0qYpCnphq4RXknVJ8BvybKRXqYVvbmdMfiJSup+k4tm5w==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/mdx-loader" "3.10.1"
-    "@docusaurus/theme-common" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-common" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/mdx-loader" "3.10.2"
+    "@docusaurus/theme-common" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-common" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     cheerio "1.0.0-rc.12"
     combine-promises "^1.1.0"
     feed "^4.2.2"
@@ -1683,20 +1693,20 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-docs@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz#261e0e982e4a937c05b462e3c5729374f433b752"
-  integrity sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==
+"@docusaurus/plugin-content-docs@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.2.tgz#249bbc806437f227b06410ecc771eb67d8910a9a"
+  integrity sha512-Sqwl4FPoZBDrlY8I2VU2H8O0M91CHp9T8ToMSkTZmjvHCif+1laqfXi6sTk8IfyVS/trN5yNjcWd1bFsGB6W5Q==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/mdx-loader" "3.10.1"
-    "@docusaurus/module-type-aliases" "3.10.1"
-    "@docusaurus/theme-common" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-common" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/mdx-loader" "3.10.2"
+    "@docusaurus/module-type-aliases" "3.10.2"
+    "@docusaurus/theme-common" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-common" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     "@types/react-router-config" "^5.0.7"
     combine-promises "^1.1.0"
     fs-extra "^11.1.1"
@@ -1707,142 +1717,141 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-pages@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz#8c6ffc2079ed0262548ecc4df1dea6add6aa9673"
-  integrity sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==
+"@docusaurus/plugin-content-pages@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.2.tgz#377c11b36a6a5e0c0c14dd9dea799f986d662ed7"
+  integrity sha512-h5R12sZ/vV9EPiVjvIl9YFCOwkpwXes7dQMYt3EvP6Pphu4amHxxTqWxf08Fl5DR8h+oZMbWpFTNw5vKEYfvzQ==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/mdx-loader" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/mdx-loader" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     fs-extra "^11.1.1"
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-css-cascade-layers@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz#440578d95cbe1a6120936fa83df868d2626cd1d8"
-  integrity sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==
+"@docusaurus/plugin-css-cascade-layers@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.2.tgz#54edc6450b0bb95be5990ea416b4c4dc5e6bdde0"
+  integrity sha512-UkdvQby5OQUKWrw3lLnSTJXQ6VETaUVTuPQX9AABtmFm5h+ifEBx1OQ+LN726Q4byuwBf2ElHkf4qU4hTxdvRg==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-debug@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-3.10.1.tgz#b8b7b24d9a7d185fd8a56a030f90145d3bfd8239"
-  integrity sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==
+"@docusaurus/plugin-debug@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-3.10.2.tgz#2452f258668bb2514085d2d5fff700457c531aad"
+  integrity sha512-8vbZNOSCpnsT57EY6CgN7sgRVmx3KTYwO8Uvo2pbxOyb8tbqAwtT9SslqaQ41HbA1v1hpn5RP7u5s2KvRwAFpQ==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
     fs-extra "^11.1.1"
     react-json-view-lite "^2.3.0"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-analytics@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz#ac15afc77386e0352edb8a1698d993aa5de36ffc"
-  integrity sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==
+"@docusaurus/plugin-google-analytics@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.2.tgz#7a0375c5a238cd9220166d9be8afc00ba508c55d"
+  integrity sha512-kMHMBK9j4VAtgd5owwrRLRIi0EjkrpXlX7ePj1+y68XfVZV9I1T4S+koPDm+Hfw2TtnyHvh0uNrDvjz+DjQGVA==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-gtag@3.10.1", "@docusaurus/plugin-google-gtag@^3.7.0":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.1.tgz#0482b83b9bc411aa99a432be2b39d2e53a00e2e0"
-  integrity sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==
+"@docusaurus/plugin-google-gtag@3.10.2", "@docusaurus/plugin-google-gtag@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.2.tgz#65df25eb5fb3f2a3f2d0fba8ddd423060e09e1ca"
+  integrity sha512-Vt90nNFhtAChRe9+it1hcHFgFvETdSnOkL5Bma+p6E/yU2tAYrvvyk+gv+LJGM2ZUkyKuKXLRsZ2Lb0bO7+Vog==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
-    "@types/gtag.js" "^0.0.20"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-tag-manager@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz#eaf5765d6f82b4fb661d92a793d1883f9d1ec106"
-  integrity sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==
+"@docusaurus/plugin-google-tag-manager@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.2.tgz#882a24e51dc42487d2c1d4f2cde3f59c99a276cb"
+  integrity sha512-MLCffCldysi/R0nzJQP7ZWd0xAoGNnSTiVOo6TTR6mKVGFhE+/XArGe67ZcaZv1uytgQXoXs92VJrgVDrz80rQ==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-sitemap@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz#66a6974bb2fd1b9d8f5cb0f3c5ecd2201c118565"
-  integrity sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==
+"@docusaurus/plugin-sitemap@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.2.tgz#6c662c7df3bb7d36887f8b73f54d85dc4d36371d"
+  integrity sha512-PODkwg5XetLML3hU/3xpCKJUZ9cqExLaBnD/Fzzwj2VHogLeqnDisLIujae87zuze7T4mCm2A6KEqZkyiz07EQ==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-common" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-common" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     fs-extra "^11.1.1"
     sitemap "^7.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-svgr@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz#c217c24d6d23fd2bc6f54d44c040635b49d6b36e"
-  integrity sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==
+"@docusaurus/plugin-svgr@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.2.tgz#916fd0a5d39bf73cb621de9789cce243a7ef1754"
+  integrity sha512-JgfT3jWM0TJ8Uw0cEcqxHpybngQY1vlBYpuuNO+gEh5iPh5Ar+vxq/u9CFrYsWeXy48BN7Db76Pzp2edNXUQ8A==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     "@svgr/core" "8.1.0"
     "@svgr/webpack" "^8.1.0"
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/preset-classic@^3.7.0":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz#faf330d96aedc9083a59bec09d966ae4dfc8b2fb"
-  integrity sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==
+"@docusaurus/preset-classic@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.10.2.tgz#e4419c811723ab913a946c63efcc15e7f5f60a0a"
+  integrity sha512-a4B3VczmDl99zK0EufDQYomdJ186WDingjmDXxhN2PNPS9Ty/Y2M5CLFX1KQMRKqRTLiRDKfutzG5IY1FC/ceg==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/plugin-content-blog" "3.10.1"
-    "@docusaurus/plugin-content-docs" "3.10.1"
-    "@docusaurus/plugin-content-pages" "3.10.1"
-    "@docusaurus/plugin-css-cascade-layers" "3.10.1"
-    "@docusaurus/plugin-debug" "3.10.1"
-    "@docusaurus/plugin-google-analytics" "3.10.1"
-    "@docusaurus/plugin-google-gtag" "3.10.1"
-    "@docusaurus/plugin-google-tag-manager" "3.10.1"
-    "@docusaurus/plugin-sitemap" "3.10.1"
-    "@docusaurus/plugin-svgr" "3.10.1"
-    "@docusaurus/theme-classic" "3.10.1"
-    "@docusaurus/theme-common" "3.10.1"
-    "@docusaurus/theme-search-algolia" "3.10.1"
-    "@docusaurus/types" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/plugin-content-blog" "3.10.2"
+    "@docusaurus/plugin-content-docs" "3.10.2"
+    "@docusaurus/plugin-content-pages" "3.10.2"
+    "@docusaurus/plugin-css-cascade-layers" "3.10.2"
+    "@docusaurus/plugin-debug" "3.10.2"
+    "@docusaurus/plugin-google-analytics" "3.10.2"
+    "@docusaurus/plugin-google-gtag" "3.10.2"
+    "@docusaurus/plugin-google-tag-manager" "3.10.2"
+    "@docusaurus/plugin-sitemap" "3.10.2"
+    "@docusaurus/plugin-svgr" "3.10.2"
+    "@docusaurus/theme-classic" "3.10.2"
+    "@docusaurus/theme-common" "3.10.2"
+    "@docusaurus/theme-search-algolia" "3.10.2"
+    "@docusaurus/types" "3.10.2"
 
-"@docusaurus/theme-classic@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz#deed8cf73cc0f56113e53775cbb3b168c3c61566"
-  integrity sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==
+"@docusaurus/theme-classic@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-3.10.2.tgz#a64bd600c789b33c67c30c256b07e2ca0f57e2ae"
+  integrity sha512-JqTSLQmqmA9uKWZsD5iwBGJ4JyKB4/yTw6PsSXVPRJG/6GAm/u+add9Iip+hvwP12/AnPNztrdxsI14NJW4KeA==
   dependencies:
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/mdx-loader" "3.10.1"
-    "@docusaurus/module-type-aliases" "3.10.1"
-    "@docusaurus/plugin-content-blog" "3.10.1"
-    "@docusaurus/plugin-content-docs" "3.10.1"
-    "@docusaurus/plugin-content-pages" "3.10.1"
-    "@docusaurus/theme-common" "3.10.1"
-    "@docusaurus/theme-translations" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-common" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/mdx-loader" "3.10.2"
+    "@docusaurus/module-type-aliases" "3.10.2"
+    "@docusaurus/plugin-content-blog" "3.10.2"
+    "@docusaurus/plugin-content-docs" "3.10.2"
+    "@docusaurus/plugin-content-pages" "3.10.2"
+    "@docusaurus/theme-common" "3.10.2"
+    "@docusaurus/theme-translations" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-common" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     "@mdx-js/react" "^3.0.0"
     clsx "^2.0.0"
     copy-text-to-clipboard "^3.2.0"
@@ -1857,15 +1866,15 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.10.1.tgz#cbfec82b1b107be5c229811ed9caae14a501361c"
-  integrity sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==
+"@docusaurus/theme-common@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.10.2.tgz#5cf2a8b76554b8b38c6afe8448470c411f683e5b"
+  integrity sha512-R9b/vMpK1yye6hNZTA6x/ivRv+at6GhxnXcxkpzCGzO1R1RwiquqiFg2wMFh6aqlJTpWRFKpFD2TzCDQcyOU0A==
   dependencies:
-    "@docusaurus/mdx-loader" "3.10.1"
-    "@docusaurus/module-type-aliases" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-common" "3.10.1"
+    "@docusaurus/mdx-loader" "3.10.2"
+    "@docusaurus/module-type-aliases" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-common" "3.10.2"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1875,20 +1884,20 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-search-algolia@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz#6f422058711629ce8d7c2f17e1e54efa075c626e"
-  integrity sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==
+"@docusaurus/theme-search-algolia@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.2.tgz#e7756d4088a7df4d11fd734bfe0e8fa28ceac1dd"
+  integrity sha512-1msxllyhi/5m77JukXtp5UFnUAriwZIC1oJ7MTnpQpCwLTbclJi5BK5n28CTZuSXpQN2ewbbnqRgAhMM6c6ihg==
   dependencies:
     "@algolia/autocomplete-core" "^1.19.2"
     "@docsearch/react" "^3.9.0 || ^4.3.2"
-    "@docusaurus/core" "3.10.1"
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/plugin-content-docs" "3.10.1"
-    "@docusaurus/theme-common" "3.10.1"
-    "@docusaurus/theme-translations" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-validation" "3.10.1"
+    "@docusaurus/core" "3.10.2"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/plugin-content-docs" "3.10.2"
+    "@docusaurus/theme-common" "3.10.2"
+    "@docusaurus/theme-translations" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-validation" "3.10.2"
     algoliasearch "^5.37.0"
     algoliasearch-helper "^3.26.0"
     clsx "^2.0.0"
@@ -1898,18 +1907,18 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-translations@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-3.10.1.tgz#c3119a015652290eea560ca45ac775963d6eb75b"
-  integrity sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==
+"@docusaurus/theme-translations@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-3.10.2.tgz#cd649083babd12df324e7129008aaccacd4cfb13"
+  integrity sha512-iv20wrxnyXkY89LM3TzRlzGlt5fIGO5UnaR6UL1ZVfB9RRFjxQFQ6awDrwAc6Km8Y5gD8pInuwYPF+6/TiCxXA==
   dependencies:
     fs-extra "^11.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/types@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.10.1.tgz#d42837938ae43ca2be0ca47e63e00476b5eb94be"
-  integrity sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==
+"@docusaurus/types@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.10.2.tgz#9ffe35adfb4587e49158ee9e10d94b86419a5932"
+  integrity sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==
   dependencies:
     "@mdx-js/mdx" "^3.0.0"
     "@types/history" "^4.7.11"
@@ -1922,43 +1931,43 @@
     webpack "^5.95.0"
     webpack-merge "^5.9.0"
 
-"@docusaurus/utils-common@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-3.10.1.tgz#6350b4898691e765de750f90eade0e0fa7902d99"
-  integrity sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==
+"@docusaurus/utils-common@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-3.10.2.tgz#a65fcfffafa4e15a59fe61d7ba315ee5d4c49269"
+  integrity sha512-x3Dz6jv6iQKBNjBmVTu8p57abMp/VNTUgKBMgRVXJc5444orBTsArv0+cdfrXTiz/VMmHfDRVkPbL7GH2B7T7w==
   dependencies:
-    "@docusaurus/types" "3.10.1"
+    "@docusaurus/types" "3.10.2"
     tslib "^2.6.0"
 
-"@docusaurus/utils-validation@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz#ddbcce997a5506424cdd16abf6845cc51692acae"
-  integrity sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==
+"@docusaurus/utils-validation@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-3.10.2.tgz#2624b0ca6675675da2f063828115b43c9a22de47"
+  integrity sha512-sn8unbDfUL585NtR3cwHefPicOyaHvPaX7VD0aOg/siIxUBoKyKKaGEqzJZDS64mM43TnxurkYDtmB1wsJlZsw==
   dependencies:
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/utils" "3.10.1"
-    "@docusaurus/utils-common" "3.10.1"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/utils" "3.10.2"
+    "@docusaurus/utils-common" "3.10.2"
     fs-extra "^11.2.0"
     joi "^17.9.2"
     js-yaml "^4.1.0"
     lodash "^4.17.21"
     tslib "^2.6.0"
 
-"@docusaurus/utils@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-3.10.1.tgz#535968caa2c9bff69f997a081b98b95b3c5d3785"
-  integrity sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==
+"@docusaurus/utils@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-3.10.2.tgz#d99c1ffc5c7961e912344269a8728ce2aad8b3dc"
+  integrity sha512-xx0W3eav2uW1NRIpuHJWNwLTC15xPNjU4Uxi9NSnd3swYC96BE3vFiT93SD8s24kmAAWNwgZwfZ2fghGZ01Lcw==
   dependencies:
-    "@docusaurus/logger" "3.10.1"
-    "@docusaurus/types" "3.10.1"
-    "@docusaurus/utils-common" "3.10.1"
+    "@11ty/gray-matter" "^1.0.0"
+    "@docusaurus/logger" "3.10.2"
+    "@docusaurus/types" "3.10.2"
+    "@docusaurus/utils-common" "3.10.2"
     escape-string-regexp "^4.0.0"
     execa "^5.1.1"
     file-loader "^6.2.0"
     fs-extra "^11.1.1"
     github-slugger "^1.5.0"
     globby "^11.1.0"
-    gray-matter "^4.0.3"
     jiti "^1.20.0"
     js-yaml "^4.1.0"
     lodash "^4.17.21"
@@ -2687,11 +2696,6 @@
     "@types/qs" "*"
     "@types/serve-static" "^1"
 
-"@types/gtag.js@^0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.20.tgz#e47edabb4ed5ecac90a079275958e6c929d7c08a"
-  integrity sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==
-
 "@types/hast@^3.0.0":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"
@@ -3085,10 +3089,10 @@ acorn@^8.0.0, acorn@^8.0.4, acorn@^8.11.0, acorn@^8.15.0, acorn@^8.16.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
-address@^1.0.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/address/-/address-1.2.2.tgz#2b5248dac5485a6390532c6a517fda2e3faac89e"
-  integrity sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==
+address@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/address/-/address-2.0.3.tgz#e910900615db3d8a20c040d4c710631062fc4ba8"
+  integrity sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -3215,13 +3219,6 @@ arg@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
   integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
-
-argparse@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
-  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
-  dependencies:
-    sprintf-js "~1.0.2"
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -4071,7 +4068,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.3.1, debug@^4.4.3:
+debug@^4.0.0, debug@^4.1.0, debug@^4.3.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -4173,13 +4170,12 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
-detect-port@^1.5.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/detect-port/-/detect-port-1.6.1.tgz#45e4073997c5f292b957cb678fb0bb8ed4250a67"
-  integrity sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==
+detect-port@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-port/-/detect-port-2.1.0.tgz#03d72644891fa451ca5609b83107a8a0ebd03f91"
+  integrity sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==
   dependencies:
-    address "^1.0.1"
-    debug "4"
+    address "^2.0.1"
 
 devlop@^1.0.0, devlop@^1.1.0:
   version "1.1.0"
@@ -4442,11 +4438,6 @@ eslint-scope@5.1.1:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
-
-esprima@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
-  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esrecurse@^4.3.0:
   version "4.3.0"
@@ -4904,16 +4895,6 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11,
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
-
-gray-matter@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-4.0.3.tgz#e893c064825de73ea1f5f7d88c7a9f7274288798"
-  integrity sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==
-  dependencies:
-    js-yaml "^3.13.1"
-    kind-of "^6.0.2"
-    section-matter "^1.0.0"
-    strip-bom-string "^1.0.0"
 
 gzip-size@^6.0.0:
   version "6.0.0"
@@ -5587,14 +5568,6 @@ joi@^17.9.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
 js-yaml@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
@@ -5648,7 +5621,7 @@ keyv@^4.5.3:
   dependencies:
     json-buffer "3.0.1"
 
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -8416,11 +8389,6 @@ spdy@^4.0.2:
     http-deceiver "^1.2.7"
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
-
-sprintf-js@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-  integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
 srcset@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary
Updates Docusaurus to **3.10.2** (latest).

### Changes
- Bump all `@docusaurus/*` packages to 3.10.2 and refresh the lockfile

### Verification
- `yarn build` (or `npm run build`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)